### PR TITLE
Fixed bug where editing events would create a duplicate instead

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -53,9 +53,9 @@ function App() {
                 <Route path="events" element={<MemberContext />}>
                   <Route index element={<Events />} />
                   <Route path=":eventId" element={<Events />} />
-                  <Route path="new" element={<EventEditor copyFrom="false"/>} />
-                  <Route path=":eventId/edit" element={<EventEditor copyFrom="false" />} />
-                  <Route path=":eventId/copy" element={<EventEditor copyFrom="true" />} />
+                  <Route path="new" element={<EventEditor copyFrom={false}/>} />
+                  <Route path=":eventId/edit" element={<EventEditor copyFrom={false} />} />
+                  <Route path=":eventId/copy" element={<EventEditor copyFrom={true} />} />
                 </Route>
                 <Route path="photos" element={<MemberContext />}>
                   <Route index element={<Albums />} />


### PR DESCRIPTION
Because App.js doesn't use typescript a string was being accidentally passed for the copyFrom prop instead of a boolean. This meant that the condition that decided whether to edit as opposed to copy always evaluated to false so we'd always duplicate. Might be worth converting App.js to typescript but I don't know how easy that is with the standard create react app plumbing. 